### PR TITLE
fix: 정보를 보여주기에 준비된 상품만 보이도록 코드 수정

### DIFF
--- a/src/main/java/com/wl2c/elswhereproductservice/domain/product/repository/TickerSymbolRepository.java
+++ b/src/main/java/com/wl2c/elswhereproductservice/domain/product/repository/TickerSymbolRepository.java
@@ -11,6 +11,6 @@ public interface TickerSymbolRepository extends JpaRepository<TickerSymbol, Long
     @Query("select ts from TickerSymbol ts " +
             "inner join ProductTickerSymbol pts " +
             "on ts.id = pts.tickerSymbol.id " +
-            "where pts.product.id = :productId ")
+            "where pts.product.id = :productId and pts.product.productState = 'ACTIVE' ")
     List<TickerSymbol> findTickerSymbolList(@Param("productId") Long productId);
 }


### PR DESCRIPTION
## Issue 번호
#4 


## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 리펙토링
- [x] 버그 수정
- [ ] 코드 스타일 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
- 기존에 INACTIVE 상품도 product-id 값을 넣어 요청하면 해당 상품을 볼 수 있었음.
  이를 막기 위해 select 쿼리문에 where 조건 추가