### PR TITLE
feat: 상품 비교에 스텝다운의 경우 AI safetyScore 값도 받아오도록 로직 추가

### DIFF
--- a/src/main/java/com/wl2c/elswhereproductservice/domain/product/model/dto/response/ResponseProductComparisonTargetDto.java
+++ b/src/main/java/com/wl2c/elswhereproductservice/domain/product/model/dto/response/ResponseProductComparisonTargetDto.java
@@ -46,7 +46,10 @@ public class ResponseProductComparisonTargetDto {
     @Schema(description = "청약 마감일", example = "2024-06-21")
     private final LocalDate subscriptionEndDate;
 
-    public ResponseProductComparisonTargetDto(Product product) {
+    @Schema(description = "AI가 판단한 상품 안전도", example = "0.89")
+    private final BigDecimal safetyScore;
+
+    public ResponseProductComparisonTargetDto(Product product, BigDecimal safetyScore) {
         this.id = product.getId();
         this.issuer = product.getIssuer();
         this.name = product.getName();
@@ -59,5 +62,6 @@ public class ResponseProductComparisonTargetDto {
         this.maximumLossRate = product.getMaximumLossRate();
         this.subscriptionStartDate = product.getSubscriptionStartDate();
         this.subscriptionEndDate = product.getSubscriptionEndDate();
+        this.safetyScore = safetyScore;
     }
 }


### PR DESCRIPTION
## Issue 번호
#93 


## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 리펙토링
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 코드 스타일 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
- 상품 비교에 스텝다운의 경우 AI safetyScore 값도 받아오도록 분석 서비스에서 값을 가져오는 로직 추가
